### PR TITLE
This PR is to fix non-utf-8 chars in lab1/extend/not2/2024/D-2.cmm

### DIFF
--- a/lab1/extend/not2/2024/D-2.cmm
+++ b/lab1/extend/not2/2024/D-2.cmm
@@ -1,4 +1,4 @@
 int main() {
-    float num1 = 0.23e-4;
-    float num2 = -9.99E6;
+    float num1 = 0.23e-4;
+    float num2 = -9.99E6;
 }


### PR DESCRIPTION
This PR is to fix #7 

There're two non-utf-8 chars ';' in lab1/extend/not2/2024/D-2.cmm, I change them with the correct char ';'. (They have the same look in github views).

After that, this test no longer crushes in the same place.

![image](https://github.com/user-attachments/assets/f11b4b8d-2248-4601-972b-014fda5cd774)


