### PR TITLE
fix(lab3/irsim): compile & runtime errors in GCC 15

### DIFF
--- a/lab3/irsim/irsim.h
+++ b/lab3/irsim/irsim.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <cassert>
 #include <climits>
+#include <cstdint>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -213,7 +214,7 @@ public:
 private:
   int *get_textptr() const { return textptr; }
   void check_eof(unsigned N) {
-    if (textptr + N + 2 >= &(*curblk)[curblk->size()]) {
+    if (textptr + N + 2 >= curblk->data() + curblk->size()) {
       curblk = new TransitionBlock;
       codes.push_back(
           std::unique_ptr<TransitionBlock>(curblk));


### PR DESCRIPTION
+ `cstdint` shall be manually included now;
+ The run time error caused by GCC 15 [Standard library hardening](https://wg21.link/P3471R4), or the default bound checking.